### PR TITLE
Lowered anti-aliasing on URP settings

### DIFF
--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -44,7 +44,7 @@ GraphicsSettings:
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
-  m_CustomRenderPipeline: {fileID: 11400000, guid: f82cf8e8434b44cca827dfd78aaa01f0,
+  m_CustomRenderPipeline: {fileID: 11400000, guid: 9066bf065b1b3b04ebb9d8e21eef10ce,
     type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -201,7 +201,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 8
+    antiAliasing: 0
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
Currently our systems running the Quest 2 can't run the game at a reasonable fps. This lowers the anti-aliasing from 8x to 2x.