### PR TITLE
Added player hit cooldown

### DIFF
--- a/Assets/Scripts/GameLogicLib/GameManager.cs
+++ b/Assets/Scripts/GameLogicLib/GameManager.cs
@@ -302,6 +302,11 @@ public class GameManager : MonoBehaviour
         // get player or AI to hit ball
         player.hitBall(listenedBall, opposingCourt);
 
+        // Stop processing after applying force if on cooldown
+        if (player.isOnHitCooldown)
+          return;
+        StartCoroutine(player.StartHitCooldown());
+
         // Switch possession or increment passes
         if (currentPossession != player.team)
         {

--- a/Assets/Scripts/GameLogicLib/Player.cs
+++ b/Assets/Scripts/GameLogicLib/Player.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using Utility;
 public class Player : MonoBehaviour
@@ -8,6 +9,9 @@ public class Player : MonoBehaviour
   private Vector3 prevLeftHandPosition;
   private Vector3 rightHandVelocity;
   private Vector3 leftHandVelocity;
+
+  public bool isOnHitCooldown = false;
+  public float hitCooldownTime = 0.5f;
 
   // Start is called before the first frame update
   public virtual void Start()
@@ -134,4 +138,9 @@ public class Player : MonoBehaviour
     }
   }
 
+  public IEnumerator StartHitCooldown() {
+    isOnHitCooldown = true;
+    yield return new WaitForSeconds(hitCooldownTime);
+    isOnHitCooldown = false;
+  }
 }


### PR DESCRIPTION
This change is to prevent the game from counting two passes if the player's hitbox collides with the ball twice in one hit. This also helps simulate hitting the ball with two hands!