### PR TITLE
Fixed mute overriding saved volume preferences

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -14,9 +14,6 @@ public class AudioManager : MonoBehaviour {
     // Game audio mixer
     public AudioMixer audioMixer;
 
-    // Saved volume to use during mute/unmute
-    private float savedVolume;
-
     // Array for easy use in inspector
     public SoundGroup[] soundGroups;
 
@@ -98,12 +95,11 @@ public class AudioManager : MonoBehaviour {
     }
 
     public void Mute() {
-        audioMixer.GetFloat("MasterVolume", out savedVolume);
         audioMixer.SetFloat("MasterVolume", -80);
     }
 
     public void Unmute() {
-        audioMixer.SetFloat("MasterVolume", savedVolume);
+        audioMixer.SetFloat("MasterVolume", PlayerPrefs.GetFloat("MasterVolume", 1f));
     }
 
     // Attempts to find sound by name. Returns null if not found.


### PR DESCRIPTION
When muting the game during scene switching, the AudioManager used to save the current master volume and restore that when done loading. If you were to Mute() twice in a row before calling Unmute(), it would save the muted volume. Now Unmute() reads from PlayerPrefs, which always has the correct target volume when unmuted.